### PR TITLE
Contain catfind code

### DIFF
--- a/controls/V-72907.rb
+++ b/controls/V-72907.rb
@@ -78,6 +78,7 @@ control "V-72907" do
 
   sql = postgres_session(pg_dba, pg_dba_password, pg_host, input('pg_port'))
 
+if file(pg_audit_log_dir).exist?  
   describe sql.query('CREAT TABLE incorrect_syntax2(id INT);', [pg_db]) do
     its('output') { should match // }     
   end
@@ -87,10 +88,11 @@ control "V-72907" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"syntax error at or near\"") do
     its('stdout') { should match /^.*syntax error at or near .CREAT..*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end 
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
-  
- end 
+  end 
+end  
+
+end 

--- a/controls/V-72907.rb
+++ b/controls/V-72907.rb
@@ -87,5 +87,10 @@ control "V-72907" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"syntax error at or near\"") do
     its('stdout') { should match /^.*syntax error at or near .CREAT..*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
+  
  end 

--- a/controls/V-72913.rb
+++ b/controls/V-72913.rb
@@ -99,6 +99,10 @@ control "V-72913" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied to set parameter\"") do
     its('stdout') { should match /^.*permission denied to set parameter .pgaudit.role..*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
 
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
+  
 end

--- a/controls/V-72913.rb
+++ b/controls/V-72913.rb
@@ -89,7 +89,7 @@ control "V-72913" do
   enabling logging."
 
   #Execute an incorrectly-formed SQL statement with bad syntax, to prompt log ouput
-
+if file(pg_audit_log_dir).exist?
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"CREATE ROLE pgauditrolefailuretest; SET ROLE pgauditrolefailuretest; SET pgaudit.role='test'; SET ROLE postgres; DROP ROLE IF EXISTS pgauditrolefailuretest;\"") do
     its('stdout') { should match // }
   end
@@ -99,10 +99,11 @@ control "V-72913" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied to set parameter\"") do
     its('stdout') { should match /^.*permission denied to set parameter .pgaudit.role..*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end 
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
+  end
+end
   
 end

--- a/controls/V-72921.rb
+++ b/controls/V-72921.rb
@@ -234,7 +234,7 @@ control "V-72921" do
   enabled, review supplementary content APPENDIX-C for instructions on enabling
   logging."
 
-
+if file(pg_audit_log_dir).exist?
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"CREATE ROLE permdeniedtest; CREATE SCHEMA permdeniedschema; SET ROLE permdeniedtest; CREATE TABLE permdeniedschema.usertable(index int);\"") do
    its('stdout') { should match // }
   end
@@ -244,14 +244,14 @@ control "V-72921" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied for schema\"") do
     its('stdout') { should match /^.*permission denied for schema permdeniedschema..*$/ }
-  end if file(pg_audit_log_dir).exist?
-
-  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
-    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
-
+  end 
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"SET ROLE postgres; DROP SCHEMA IF EXISTS permdeniedschema; DROP ROLE IF EXISTS permdeniedtest;\"") do
    its('stdout') { should match // }
   end
+else
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end
+end
 
 end

--- a/controls/V-72921.rb
+++ b/controls/V-72921.rb
@@ -244,7 +244,11 @@ control "V-72921" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied for schema\"") do
     its('stdout') { should match /^.*permission denied for schema permdeniedschema..*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
 
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"SET ROLE postgres; DROP SCHEMA IF EXISTS permdeniedschema; DROP ROLE IF EXISTS permdeniedtest;\"") do
    its('stdout') { should match // }

--- a/controls/V-72923.rb
+++ b/controls/V-72923.rb
@@ -95,17 +95,18 @@ control "V-72923" do
   # INITD SERVER ONLY 
   $ sudo service postgresql-${PGVER?} reload"
 
-
+if file(pg_audit_log_dir).exist?
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"SET ROLE pgauditrolefailuretest;\"") do
     its('stdout') { should match // }
   end
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"does not exist\"") do
     its('stdout') { should match /^.*role \"pgauditrolefailuretest\" does not exist.*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end 
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
+  end 
+end
 
 end

--- a/controls/V-72923.rb
+++ b/controls/V-72923.rb
@@ -102,5 +102,10 @@ control "V-72923" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"does not exist\"") do
     its('stdout') { should match /^.*role \"pgauditrolefailuretest\" does not exist.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
+
 end

--- a/controls/V-72925.rb
+++ b/controls/V-72925.rb
@@ -105,6 +105,10 @@ possible, all disconnections must be logged."
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"connection authorized\"") do
     its('stdout') { should match /^.*user=postgres.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
 
 end

--- a/controls/V-72925.rb
+++ b/controls/V-72925.rb
@@ -102,13 +102,14 @@ possible, all disconnections must be logged."
 
   # INITD SERVER ONLY 
   $ sudo service postgresql-${PGVER?} reload"
-
+if file(pg_audit_log_dir).exist?
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"connection authorized\"") do
     its('stdout') { should match /^.*user=postgres.*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end 
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
+  end
+end
 
 end

--- a/controls/V-72927.rb
+++ b/controls/V-72927.rb
@@ -79,17 +79,18 @@ control "V-72927" do
   enabled. To ensure that logging is enabled, review supplementary content
   APPENDIX-C for instructions on enabling logging."
 
-  
+if file(pg_audit_log_dir).exist?  
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"CREATE ROLE permdeniedtest; SET ROLE permdeniedtest; UPDATE pg_authid SET rolsuper = 't' WHERE rolname = 'permdeniedtest'; DROP ROLE IF EXISTS permdeniedtest;\"") do
     its('stdout') { should match // }
   end
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied for relation pg_authid\"") do
     its('stdout') { should match /^.*permission denied for relation pg_authid.*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end 
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
+  end
+end
 
 end

--- a/controls/V-72927.rb
+++ b/controls/V-72927.rb
@@ -86,6 +86,10 @@ control "V-72927" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied for relation pg_authid\"") do
     its('stdout') { should match /^.*permission denied for relation pg_authid.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
 
 end

--- a/controls/V-72929.rb
+++ b/controls/V-72929.rb
@@ -102,21 +102,22 @@ control "V-72929" do
 
   # INITD SERVER ONLY 
   $ sudo service postgresql-${PGVER?} reload"
-
+if file(pg_audit_log_dir).exist?
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"CREATE ROLE fooaudit; GRANT CONNECT ON DATABASE postgres TO fooaudit; REVOKE CONNECT ON DATABASE postgres FROM fooaudit;\"") do
     its('stdout') { should match // }
   end
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"GRANT CONNECT ON DATABASE postgres TO\"") do
     its('stdout') { should match /^.*fooaudit.*$/ }
-  end if file(pg_audit_log_dir).exist?
+  end 
   
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"REVOKE CONNECT ON DATABASE postgres FROM\"") do
     its('stdout') { should match /^.*fooaudit.*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
+  end 
+end
 
 end

--- a/controls/V-72929.rb
+++ b/controls/V-72929.rb
@@ -109,10 +109,14 @@ control "V-72929" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"GRANT CONNECT ON DATABASE postgres TO\"") do
     its('stdout') { should match /^.*fooaudit.*$/ }
-  end
-
+  end if file(pg_audit_log_dir).exist?
+  
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"REVOKE CONNECT ON DATABASE postgres FROM\"") do
     its('stdout') { should match /^.*fooaudit.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
 
 end

--- a/controls/V-72933.rb
+++ b/controls/V-72933.rb
@@ -94,17 +94,18 @@ control "V-72933" do
   # INITD SERVER ONLY 
   $ sudo service postgresql-${PGVER?} reload"
 
-
+if file(pg_audit_log_dir).exist?
  describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"SHOW log_connections\"") do
    its('stdout') { should match /on/ }
  end
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"connection authorized\"") do
     its('stdout') { should match /^.*user=postgres.*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end 
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
+  end
+end
 
 end

--- a/controls/V-72933.rb
+++ b/controls/V-72933.rb
@@ -101,6 +101,10 @@ control "V-72933" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"connection authorized\"") do
     its('stdout') { should match /^.*user=postgres.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
 
 end

--- a/controls/V-72939.rb
+++ b/controls/V-72939.rb
@@ -100,26 +100,30 @@ control "V-72939" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT: SESSION\"") do
     its('stdout') { should match /^.*CREATE TABLE,TABLE,public.stig_test.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT: SESSION\"") do
     its('stdout') { should match /^.*ALTER TABLE stig_test ENABLE ROW LEVEL SECURITY.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT: SESSION\"") do
     its('stdout') { should match /^.*CREATE POLICY,POLICY,lock_table.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT: SESSION\"") do
     its('stdout') { should match /^.*DROP POLICY lock_table ON stig_test.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT: SESSION\"") do
     its('stdout') { should match /^.*ALTER TABLE stig_test DISABLE ROW LEVEL SECURITY.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT: SESSION\"") do
     its('stdout') { should match /^.*DROP TABLE stig_test.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
 
 end

--- a/controls/V-72939.rb
+++ b/controls/V-72939.rb
@@ -93,37 +93,38 @@ control "V-72939" do
 
   # INITD SERVER ONLY 
   $ sudo service postgresql-${PGVER?} reload"
-
+if file(pg_audit_log_dir).exist?
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"CREATE TABLE stig_test(id INT); ALTER TABLE stig_test ENABLE ROW LEVEL SECURITY; CREATE POLICY lock_table ON stig_test USING ('postgres' = current_user); DROP POLICY lock_table ON stig_test; ALTER TABLE stig_test DISABLE ROW LEVEL SECURITY; DROP TABLE stig_test;\"") do
     its('stdout') { should match // }
   end
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT: SESSION\"") do
     its('stdout') { should match /^.*CREATE TABLE,TABLE,public.stig_test.*$/ }
-  end if file(pg_audit_log_dir).exist?
+  end 
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT: SESSION\"") do
     its('stdout') { should match /^.*ALTER TABLE stig_test ENABLE ROW LEVEL SECURITY.*$/ }
-  end if file(pg_audit_log_dir).exist?
+  end 
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT: SESSION\"") do
     its('stdout') { should match /^.*CREATE POLICY,POLICY,lock_table.*$/ }
-  end if file(pg_audit_log_dir).exist?
+  end 
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT: SESSION\"") do
     its('stdout') { should match /^.*DROP POLICY lock_table ON stig_test.*$/ }
-  end if file(pg_audit_log_dir).exist?
+  end 
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT: SESSION\"") do
     its('stdout') { should match /^.*ALTER TABLE stig_test DISABLE ROW LEVEL SECURITY.*$/ }
-  end if file(pg_audit_log_dir).exist?
+  end
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT: SESSION\"") do
     its('stdout') { should match /^.*DROP TABLE stig_test.*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end 
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
+  end 
+end
 
 end

--- a/controls/V-72941.rb
+++ b/controls/V-72941.rb
@@ -82,17 +82,18 @@ control "V-72941" do
   enabled, review supplementary content APPENDIX-C for instructions on enabling
   logging."
 
-
+if file(pg_audit_log_dir).exist?
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"CREATE ROLE fooaudit; SET ROLE fooaudit; SELECT * FROM pg_authid; SET ROLE postgres; DROP ROLE fooaudit;\"") do
     its('stdout') { should match // }
   end
 
  describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied for relation\"") do
    its('stdout') { should match /^.*pg_authid.*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end 
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
+  end
+end
 
 end

--- a/controls/V-72941.rb
+++ b/controls/V-72941.rb
@@ -89,6 +89,10 @@ control "V-72941" do
 
  describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied for relation\"") do
    its('stdout') { should match /^.*pg_authid.*$/ }
- end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
 
 end

--- a/controls/V-72945.rb
+++ b/controls/V-72945.rb
@@ -78,17 +78,18 @@ control "V-72945" do
   All denials are logged if logging is enabled. To ensure that logging is
   enabled, review supplementary content APPENDIX-C for instructions on enabling
   logging."
-
+if file(pg_audit_log_dir).exist?
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"CREATE ROLE pgauditrolefailuretest; SET ROLE pgauditrolefailuretest; DROP ROLE postgres; SET ROLE postgres; DROP ROLE pgauditrolefailuretest;\"") do
     its('stdout') { should match // }
   end
 
  describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied to drop role\"") do
    its('stdout') { should match /^.*permission denied to drop role.*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end 
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
+  end
+end
 
 end

--- a/controls/V-72945.rb
+++ b/controls/V-72945.rb
@@ -85,6 +85,10 @@ control "V-72945" do
 
  describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied to drop role\"") do
    its('stdout') { should match /^.*permission denied to drop role.*$/ }
- end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
 
 end

--- a/controls/V-72947.rb
+++ b/controls/V-72947.rb
@@ -105,17 +105,18 @@ control "V-72947" do
     
   # INITD SERVER ONLY 
   $ sudo service postgresql-${PGVER?} reload"
-
+if file(pg_audit_log_dir).exist?
  describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"\\du\"") do
    its('stdout') { should match // }
  end
 
  describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT\"") do
    its('stdout') { should match /^.*pg_catalog.pg_roles.*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end 
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
+  end 
+end
 
 end

--- a/controls/V-72947.rb
+++ b/controls/V-72947.rb
@@ -112,6 +112,10 @@ control "V-72947" do
 
  describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"AUDIT\"") do
    its('stdout') { should match /^.*pg_catalog.pg_roles.*$/ }
- end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
 
 end

--- a/controls/V-72951.rb
+++ b/controls/V-72951.rb
@@ -163,9 +163,14 @@ control "V-72951" do
 
     describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied for schema test_schema\"") do
       its('stdout') { should match /^.*permission denied for schema test_schema.*$/ }
-    end
+    end if file(pg_audit_log_dir).exist?
 
     describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"must be owner of schema test_schema\"") do
       its('stdout') { should match /^.*must be owner of schema test_schema.*$/ }
-    end
+    end if file(pg_audit_log_dir).exist?
+
+    describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+      skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+    end if !file(pg_audit_log_dir).exist?
+
 end

--- a/controls/V-72951.rb
+++ b/controls/V-72951.rb
@@ -114,6 +114,8 @@ control "V-72951" do
 
     sql = postgres_session(pg_dba, pg_dba_password, pg_host, input('pg_port'))
 
+  if file(pg_audit_log_dir).exist?
+    
     describe sql.query('DROP TABLE IF EXISTS test_schema.test_table;', [pg_db]) do
       its('output') { should eq 'DROP TABLE' }
     end
@@ -163,14 +165,16 @@ control "V-72951" do
 
     describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied for schema test_schema\"") do
       its('stdout') { should match /^.*permission denied for schema test_schema.*$/ }
-    end if file(pg_audit_log_dir).exist?
+    end 
 
     describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"must be owner of schema test_schema\"") do
       its('stdout') { should match /^.*must be owner of schema test_schema.*$/ }
-    end if file(pg_audit_log_dir).exist?
+    end 
 
+else
     describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
       skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-    end if !file(pg_audit_log_dir).exist?
+    end
+end
 
 end

--- a/controls/V-72969.rb
+++ b/controls/V-72969.rb
@@ -111,7 +111,7 @@ execute privileged activities or other system-level access occur."
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"must be superuser to create superusers\"") do
     its('stdout') { should match /^.*must be superuser to create superusers.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
 
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"CREATE ROLE fooauditbad CREATEDB; CREATE ROLE fooauditbad CREATEROLE\"") do
     its('stdout') { should match // }
@@ -119,6 +119,10 @@ execute privileged activities or other system-level access occur."
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied to create role\"") do
     its('stdout') { should match /^.*permission denied to create role.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
 
 end

--- a/controls/V-72969.rb
+++ b/controls/V-72969.rb
@@ -104,14 +104,14 @@ execute privileged activities or other system-level access occur."
   is enabled, review supplementary content APPENDIX-C for instructions on
   enabling logging."
 
-
+if file(pg_audit_log_dir).exist?
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"CREATE ROLE fooaudit; SET ROLE fooaudit; CREATE ROLE fooauditbad SUPERUSER;\"") do
     its('stdout') { should match // }
   end
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"must be superuser to create superusers\"") do
     its('stdout') { should match /^.*must be superuser to create superusers.*$/ }
-  end if file(pg_audit_log_dir).exist?
+  end 
 
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"CREATE ROLE fooauditbad CREATEDB; CREATE ROLE fooauditbad CREATEROLE\"") do
     its('stdout') { should match // }
@@ -119,10 +119,11 @@ execute privileged activities or other system-level access occur."
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied to create role\"") do
     its('stdout') { should match /^.*permission denied to create role.*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end 
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
+  end 
+end
 
 end

--- a/controls/V-72975.rb
+++ b/controls/V-72975.rb
@@ -78,17 +78,18 @@ control "V-72975" do
   All denials are logged by default if logging is enabled. To ensure that logging
   is enabled, review supplementary content APPENDIX-C for instructions on
   enabling logging."
-
+if file(pg_audit_log_dir).exist?
   describe command("PGPASSWORD='#{pg_dba_password}' psql -U #{pg_dba} -d #{pg_db} -h #{pg_host} -A -t -c \"CREATE ROLE fooaudit; CREATE TABLE fooaudittest (id int); SET ROLE fooaudit; GRANT ALL PRIVILEGES ON fooaudittest TO fooaudit; DROP TABLE IF EXISTS fooaudittest;\"") do
     its('stdout') { should match // }
   end
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied for relation\"") do
    its('stdout') { should match /^.*pg_authid.*$/ }
-  end if file(pg_audit_log_dir).exist?
-
+  end 
+else
   describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
     skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
+  end
+end
 
 end

--- a/controls/V-72975.rb
+++ b/controls/V-72975.rb
@@ -85,5 +85,10 @@ control "V-72975" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied for relation\"") do
    its('stdout') { should match /^.*pg_authid.*$/ }
-  end   
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
+
 end

--- a/controls/V-72977.rb
+++ b/controls/V-72977.rb
@@ -85,7 +85,11 @@ control "V-72977" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied for relation test\"") do
     its('stdout') { should match /^.*permission denied for relation test.*$/ }
-  end
+  end if file(pg_audit_log_dir).exist?
+
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end if !file(pg_audit_log_dir).exist?
 
   describe sql.query('DROP ROLE bob; DROP TABLE "test" CASCADE', [pg_db]) do
   end

--- a/controls/V-72977.rb
+++ b/controls/V-72977.rb
@@ -74,7 +74,7 @@ control "V-72977" do
   enabling logging."
 
   sql = postgres_session(pg_dba, pg_dba_password, pg_host, input('pg_port'))
-  
+if file(pg_audit_log_dir).exist?  
   describe sql.query('DROP ROLE IF EXISTS bob; CREATE ROLE bob; CREATE TABLE test(id INT);', [pg_db]) do
     its('output') { should match /CREATE TABLE/ }
   end
@@ -85,12 +85,14 @@ control "V-72977" do
 
   describe command("cat `find #{pg_audit_log_dir} -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d\" \"` | grep \"permission denied for relation test\"") do
     its('stdout') { should match /^.*permission denied for relation test.*$/ }
-  end if file(pg_audit_log_dir).exist?
-
-  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
-    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
-  end if !file(pg_audit_log_dir).exist?
-
+  end 
+  
   describe sql.query('DROP ROLE bob; DROP TABLE "test" CASCADE', [pg_db]) do
   end
+else
+  describe "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter." do
+    skip "The #{pg_audit_log_dir} directory was not found. Check path for this postgres version/install to define the value for the 'pg_audit_log_dir' inspec input parameter."
+  end
+end
+
 end


### PR DESCRIPTION
Updates to V-72907, 13, 21-29, 33, 39, 41, 45, 47, 51, 69, 75, 77 to contain the describe blocks based on use of a "cat `find..." approach to review postgres audit logs. An if statement is used to skip the normal attempts to check things if the input "pg_audit_log_dir" isn't pointing to an actual directory on the target. (if it is not, the current code will pause). 